### PR TITLE
Fix a bug where locale parsing information is passed incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.3.3
+* Fix a bug where locale parsing information is passed incorrectly.
+    * The order of parameters for the Locale class in ilib-locale is language, region, variant, script.
+
+
 ### v1.3.2
 * Add the missing `ko-TW` and `ko-US` locales to the LocaleMatcher.
 * Add the missing `ko-CN` locale to the LocaleMatcher.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localematcher",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "main": "./lib/LocaleMatcher.js",
     "module": "./src/LocaleMatcher.js",
     "exports": {

--- a/src/LocaleMatcher.js
+++ b/src/LocaleMatcher.js
@@ -91,22 +91,22 @@ class LocaleMatcher {
 
         if (typeof(matchdata.likelyLocales[locale.getSpec()]) === 'undefined') {
             // try various partials before giving up
-            let partial = matchdata.likelyLocales[new Locale(locale.language, undefined, locale.region).getSpec()];
+            let partial = matchdata.likelyLocales[new Locale(locale.language, locale.region, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(locale.language, locale.script, undefined).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(locale.language, undefined, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
             partial = matchdata.likelyLocales[new Locale(locale.language, undefined, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, locale.script, locale.region).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, locale.region, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, undefined, locale.region).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, locale.region, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, locale.script, undefined).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, undefined, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
             return locale;
@@ -161,7 +161,7 @@ class LocaleMatcher {
         const fullLocale = this._getLikelyLocale(this.locale);
         const langLocale = this._getLikelyLocale(new Locale(fullLocale.language));
         return fullLocale.script === langLocale.script && !multiScriptLanguages[fullLocale.language] ?
-            new Locale(fullLocale.language, undefined, fullLocale.region) :
+            new Locale(fullLocale.language, fullLocale.region, undefined) :
             fullLocale;
     }
 

--- a/test/localematch.test.js
+++ b/test/localematch.test.js
@@ -183,6 +183,40 @@ describe("testLocaleMatch", () => {
         expect(locale.getSpec()).toBe("arc-Elym-IR");
     });
 
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptArab", () => {
+        expect.assertions(3);
+        debugger;
+        var lm = new LocaleMatcher({
+            locale: "und-Arab"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ar-Arab-EG");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptHans", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "und-Hans"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("zh-Hans-CN");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptCyrl", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "und-Cyrl"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ru-Cyrl-RU");
+    });
+
     test("LocaleMatcherGetLikelyLocaleByLanguageAndScript1", () => {
         expect.assertions(3);
         var lm = new LocaleMatcher({
@@ -280,6 +314,28 @@ describe("testLocaleMatch", () => {
         var locale = lm.getLikelyLocale();
         expect(typeof(locale) !== "undefined").toBeTruthy();
         expect(locale.getSpec()).toBe("fr-Latn-MA");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByRegionAndScript2", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "Arab-IN"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ur-Arab-IN");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByRegionAndScript3", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "Deva-PK"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("btv-Deva-PK");
     });
 
     test("LocaleMatcherGetLikelyLocaleAlreadySpecified", () => {

--- a/test/localematch.test.js
+++ b/test/localematch.test.js
@@ -185,7 +185,6 @@ describe("testLocaleMatch", () => {
 
     test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptArab", () => {
         expect.assertions(3);
-        debugger;
         var lm = new LocaleMatcher({
             locale: "und-Arab"
         });


### PR DESCRIPTION
* Fix a bug where locale parsing information is passed incorrectly.
    * The order of parameters for the Locale class in ilib-locale is language, region, variant, script.